### PR TITLE
fix(trivy): avoid panic loading basic auth secret

### DIFF
--- a/plugins/trivy/pkg/config/resolver.go
+++ b/plugins/trivy/pkg/config/resolver.go
@@ -58,7 +58,12 @@ func (r *Resolver) Clientset() (*k8s.Clientset, error) {
 		return r.clientset, nil
 	}
 
-	clientset, err := k8s.NewForConfig(r.k8sConfig)
+	k8sConfig, err := r.K8sConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := k8s.NewForConfig(k8sConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -116,13 +121,16 @@ func (r *Resolver) Logger() *zap.Logger {
 }
 
 func (r *Resolver) Server(ctx context.Context, options []server.ServerOption) (*server.Server, error) {
-	var err error
 	basicAuth := &r.config.Server.BasicAuth
 
 	if basicAuth.SecretRef != "" {
-		if basicAuth, err = r.LoadBasicAuth(ctx, r.config.Server.BasicAuth.SecretRef); err != nil {
+		loadedBasicAuth, err := r.LoadBasicAuth(ctx, r.config.Server.BasicAuth.SecretRef)
+		if err != nil {
 			zap.L().Error("failed to load basic auth secret", zap.Error(err))
+			return nil, err
 		}
+
+		basicAuth = loadedBasicAuth
 	}
 
 	if basicAuth.Username != "" && basicAuth.Password != "" {


### PR DESCRIPTION
## Description

Fixes the startup crash when `server.basicAuth.secretRef` is configured and the referenced Secret cannot be loaded.

### Related Issue

Fixes #354 

### Proposed Changes

* Ensure the Kubernetes client configuration is initialized before creating the clientset.
* Return Secret loading errors immediately instead of continuing with a nil `BasicAuth` instance.
* Prevent nil pointer dereferences during server startup when Secret resolution fails.
* Improve startup error handling by failing gracefully and surfacing the underlying error.

### Testing

* Reproduced the issue locally using a configuration with `server.basicAuth.secretRef`.
* Verified that the plugin previously panicked with a nil pointer dereference.
* Verified that after the fix the plugin returns the underlying error and exits gracefully without crashing.
